### PR TITLE
Edit include sections of .h and .cpp files

### DIFF
--- a/src/BaseHSM.cpp
+++ b/src/BaseHSM.cpp
@@ -1,9 +1,8 @@
 #include <stdlib.h>
-#include <dlfcn.h>
-#include <string>
+#include <dlfcn.h>    // dlopen
 
-#include "pkcs11.h"
-#include "log.h"
+#include "log.h"      // logging macros
+
 #include "BaseHSM.h"
 
 bool allFunctionsNonNULL(CK_FUNCTION_LIST_PTR list) {

--- a/src/BaseHSM.h
+++ b/src/BaseHSM.h
@@ -1,9 +1,9 @@
 #ifndef _QRYPT_BASEHSM_H
 #define _QRYPT_BASEHSM_H
 
-#include <string>
+#include <string>     // std::string
 
-#include "cryptoki.h"
+#include "cryptoki.h" // PKCS#11 types
 
 class BaseHSM {
     public:

--- a/src/GlobalData.cpp
+++ b/src/GlobalData.cpp
@@ -1,8 +1,10 @@
 #include <stdlib.h>
-#include <dlfcn.h>
+#include <stdexcept>     // std::runtime_error
 
-#include "log.h"
-#include "osmutex.h"
+#include "log.h"                    // logging macros
+#include "osmutex.h"                // mutex functions
+#include "MeteringClientWrapper.h"  // MeteringClientWrapper
+
 #include "GlobalData.h"
 
 GlobalData::GlobalData() {

--- a/src/GlobalData.h
+++ b/src/GlobalData.h
@@ -1,10 +1,11 @@
 #ifndef _QRYPT_WRAPPER_GLOBALDATA_H
 #define _QRYPT_WRAPPER_GLOBALDATA_H
 
-#include "cryptoki.h"
-#include "BaseHSM.h"
-#include "RandomBuffer.h"
-#include "RandomCollector.h"
+#include "cryptoki.h"         // PKCS#11 types
+
+#include "BaseHSM.h"          // BaseHSM
+#include "RandomCollector.h"  // RandomCollector
+#include "RandomBuffer.h"     // RandomBuffer
 
 class GlobalData {
     public:

--- a/src/MeteringClientWrapper.cpp
+++ b/src/MeteringClientWrapper.cpp
@@ -2,12 +2,11 @@
  * Edited from file of the same name in QDARACLI -Sam
  */
 
-#include <cstring>
-#include <fstream>
+#include <cstring>     // strncmp
+
+#include "log.h"       // logging macros
 
 #include "MeteringClientWrapper.h"
-#include "HttpRandomGetter.h"
-#include "log.h"
 
 MeteringClientWrapper::MeteringClientWrapper(std::string token) {
     this->token = token;

--- a/src/MeteringClientWrapper.h
+++ b/src/MeteringClientWrapper.h
@@ -5,17 +5,13 @@
 #ifndef _QRYPT_WRAPPER_METERINGCLIENT_H
 #define _QRYPT_WRAPPER_METERINGCLIENT_H
 
-#include <map>
-#include <memory>
-#include <mutex>
-#include <string>
-#include <vector>
+#include <memory>     // std::shared_ptr
+#include <string>     // std::string
 
-#include "cryptoki.h"
-#include "HttpRandomGetter.h"
-#include "RandomCollector.h"
+#include "cryptoki.h"            // CK_RV
+#include "HttpRandomGetter.h"    // meteringclientlib::HttpRandomGetter
+#include "RandomCollector.h"     // RandomCollector
 
-const uint64_t KB = 1024;
 const std::string EAAS_API_ENDPOINT = "api-eus.qrypt.com";
 
 // MeteringClientWrapper is a wrapper class to pull random from MeteringClient

--- a/src/RandomBuffer.cpp
+++ b/src/RandomBuffer.cpp
@@ -1,7 +1,9 @@
-#include <string.h>
-#include <sys/mman.h>
+#include <cstring>         // memset
+#include <sys/mman.h>      // mlock
+#include <stdexcept>       // std::runtime_error
 
-#include "log.h"
+#include "log.h"           // DEBUG_MSG
+
 #include "RandomBuffer.h"
 
 // Zero out buffer[lo, hi)

--- a/src/RandomBuffer.h
+++ b/src/RandomBuffer.h
@@ -1,10 +1,9 @@
 #ifndef _QRYPT_WRAPPER_RANDOMBUFFER_H
 #define _QRYPT_WRAPPER_RANDOMBUFFER_H
 
-#include <string>
+#include "cryptoki.h"          // CK_RV
 
-#include "cryptoki.h"
-#include "MeteringClientWrapper.h"
+#include "RandomCollector.h"   // RandomCollector
 
 class RandomBuffer {
     public:

--- a/src/RandomCollector.h
+++ b/src/RandomCollector.h
@@ -1,9 +1,9 @@
 #ifndef _QRYPT_RANDOM_COLLECTOR_H
 #define _QRYPT_RANDOM_COLLECTOR_H
 
-#include <string>
+#include "cryptoki.h"   // CK_RV
 
-#include "cryptoki.h"
+const uint64_t KB = 1024;
 
 class RandomCollector {
     public:

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -30,11 +30,11 @@
  Implements logging functions.
  *****************************************************************************/
 
-#include <stdarg.h>
-#include <syslog.h>
-#include <stdio.h>
-#include <sstream>
-#include <vector>
+#include <stdarg.h>   // va_*
+#include <stdio.h>    // fprintf, fflush, stderr
+#include <sstream>    // std::stringstream
+#include <vector>     // std::vector
+
 #include "log.h"
 
 const int DEFAULT_MAX_LOG_LEVEL = LOG_INFO;

--- a/src/log.h
+++ b/src/log.h
@@ -33,7 +33,7 @@
 #ifndef _QRYPT_WRAPPER_LOG_H
 #define _QRYPT_WRAPPER_LOG_H
 
-#include <syslog.h> // LOG_ERR, etc.
+#include <syslog.h>     // LOG_ERR, etc.
 
 /* Logging errors */
 #ifndef _WIN32

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,15 +38,11 @@
 #define CRYPTOKI_EXPORTS
 
 #include <stdlib.h>
-#include <dlfcn.h>
-#include <string.h>
-#include <string>
-#include <vector>
+#include <cstring>         // strncpy, memset
 
-#include "cryptoki.h"
-#include "log.h"
-#include "GlobalData.h"
-#include "RandomBuffer.h"
+#include "cryptoki.h"      // PKCS#11 types
+#include "log.h"           // logging macros
+#include "GlobalData.h"    // GlobalData
 
 #if defined(__GNUC__) && \
 	(__GNUC__ >= 4 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 3)) || \

--- a/src/osmutex.cpp
+++ b/src/osmutex.cpp
@@ -31,9 +31,9 @@
  Contains OS-specific implementations of intraprocess mutex functions.
  *****************************************************************************/
 
-#include "log.h"
+#include "log.h" // logging macros
+
 #include "osmutex.h"
-#include "cryptoki.h"
 
 // My feeble attempt to try and get this to cross-compile
 #define HAVE_PTHREAD_H 1


### PR DESCRIPTION
Previously, everything worked, but there were extraneous includes that hid the true dependencies in the code. Now that is cleaned up and all non-stdlib includes are explicitly justified.