### PR TITLE
Refer to wiki for requirements setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If all tests pass, you're good to go! The library to link to is build/libqryptok
 
 ## Documentation, support, and feedback
 
-Nonexistent (for now).
+Check out the repo's wiki pages here on GitHub!
 
 ## Contributing
 


### PR DESCRIPTION
Removes cluttering details (like name of packages in Ubuntu/Fedora) from README and instead refers to wiki page.