### PR TITLE
Valgrind bug fixes

### DIFF
--- a/gtests/BufferTests.cpp
+++ b/gtests/BufferTests.cpp
@@ -215,8 +215,12 @@ TEST(BufferTests, NoReuse) {
         output_stream_bytes_idx += request_size_in_bytes;
     }
 
-    bool *seen = new bool[total_random_in_64_bits];
-    for(size_t i = 0; i < total_random_in_64_bits; i++)
+    // Possible values in output_stream go from 1 to total_random_in_64_bits
+    // We expect 0 to never appear and anything from 1 to total_random_in_64_bits
+    // to appear at most once.
+
+    bool *seen = new bool[total_random_in_64_bits + 1];
+    for(size_t i = 0; i < total_random_in_64_bits + 1; i++)
         seen[i] = false;
 
     for(size_t i = 0; i < sum_request_sizes_in_64_bits; i++) {

--- a/gtests/GenerateRandomTests.cpp
+++ b/gtests/GenerateRandomTests.cpp
@@ -191,6 +191,12 @@ TEST (GenerateRandomTests, ValidRequestManyThreads) {
     const size_t len = 300;
     CK_BYTE data[NUM_THREADS][len];
 
+    for(size_t i = 0; i < NUM_THREADS; i++) {
+        for(size_t j = 0; j < len; j++) {
+            data[i][j] = (CK_BYTE)0;
+        }
+    }
+
     for(size_t i = 0; i < NUM_THREADS; i++)
         threads[i] = std::thread(getRandom, slotID, data[i], len, std::ref(rvs[i]));
     


### PR DESCRIPTION
Fixes:
* Zero out data array in multi-threaded test case so that it is always initialized before allZeroes() is called
* Extend seen array (of bools) in NoReuse test case by one so that all values in range 0...total_random_in_64_bits have slots