### PR TITLE
Update README title to match repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Qryptoki
+# Qrypt-PKCS-11
 
 ## Introduction
 
-Qryptoki is a wrapper of the PKCS#11 interface that returns quantum-sourced entropy to C_GenerateRandom calls.
+This repository contains the source code for qryptoki, a wrapper of the PKCS#11 interface that returns quantum-sourced entropy to C_GenerateRandom calls.
 
 ## Requirements
   * Supported OSes


### PR DESCRIPTION
Alison mentioned there may be some confusion between "qryptoki" and "Qrypt-PKCS-11", and I agree. This is an in-progress PR to start resolving this potential confusion.