### PR TITLE
Add no reuse multithread test

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cmake ..
 make
 ```
 
-Now, we run the unit tests. (Don't worry! They only use your token for about 6KB of Qrypt entropy.)
+Now, we run the unit tests. (Don't worry! They only use your token for about 20KB of Qrypt entropy.)
 ```
 src/gtests/qryptoki_gtests
 ```
@@ -49,7 +49,7 @@ If the unit tests pass, go ahead and install:
 make install   # Installs to (top-level) package/ folder
 ```
 
-You can now try the integration tests (which also consume 6KB of entropy):
+You can now try the integration tests (which also consume 20KB of entropy):
 ```
 cd ../integration-tests
 mkdir build && cd build

--- a/integration-tests/test-sources/GenerateRandomTests.cpp
+++ b/integration-tests/test-sources/GenerateRandomTests.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <thread>
+#include <set>
 
 #include "qryptoki_pkcs11_vendor_defs.h"
 
@@ -317,6 +318,65 @@ bool validRequestManyThreads(CK_FUNCTION_LIST_PTR fn_list) {
     return true;
 }
 
+bool noReuseManyThreads(CK_FUNCTION_LIST_PTR fn_list) {
+    CK_RV rv;
+    finalize(fn_list);
+
+    const size_t NUM_THREADS = 100;
+    const size_t MAX_REQUEST_SIZE_IN_BYTES = 256;
+    std::thread threads[NUM_THREADS];
+    CK_RV rvs[NUM_THREADS];
+
+    const size_t BYTES_PER_32_BITS = 4;
+
+    rv = initializeMultiThreaded(fn_list);
+    if(rv != CKR_OK) return false;
+
+    CK_SLOT_ID slotID;
+
+    rv = getIntegrationTestSlot(fn_list, slotID);
+    if(rv != CKR_OK) return false;
+
+    size_t request_sizes_in_bytes[NUM_THREADS];
+    CK_BYTE data[NUM_THREADS][MAX_REQUEST_SIZE_IN_BYTES];
+
+    for(size_t i = 0; i < NUM_THREADS; i++) {
+        size_t size_in_32_bits = (rand() % MAX_REQUEST_SIZE_IN_BYTES) / BYTES_PER_32_BITS;
+        request_sizes_in_bytes[i] = BYTES_PER_32_BITS * size_in_32_bits;
+
+        for(size_t j = 0; j < MAX_REQUEST_SIZE_IN_BYTES; j++) {
+            data[i][j] = (CK_BYTE)0;
+        }
+    }
+
+    for(size_t i = 0; i < NUM_THREADS; i++) {
+        threads[i] = std::thread(getRandom, fn_list, slotID, data[i], request_sizes_in_bytes[i], std::ref(rvs[i]));
+    }
+
+    for(size_t i = 0; i < NUM_THREADS; i++) {
+        threads[i].join();
+    }
+
+    for(size_t i = 0; i < NUM_THREADS; i++) {
+        if(rvs[i] != CKR_OK) return false;
+        if(request_sizes_in_bytes[i] != 0 && allZeroes(data[i], request_sizes_in_bytes[i]))
+            return false;
+    }
+
+    std::set<uint32_t> seen;
+
+    for(size_t i = 0; i < NUM_THREADS; i++) {
+        uint32_t *data_in_32_bits = (uint32_t *)data[i];
+
+        for(size_t j =  0; j < request_sizes_in_bytes[i] / BYTES_PER_32_BITS; j++) {
+            if(seen.count(data_in_32_bits[j]) != 0) return false;
+            seen.insert(data_in_32_bits[j]);
+        }
+    }
+
+    return true;
+}
+
 } // generaterandomtests
 
 void runGenerateRandomTests(CK_FUNCTION_LIST_PTR fn_list,
@@ -399,6 +459,13 @@ void runGenerateRandomTests(CK_FUNCTION_LIST_PTR fn_list,
 
     if(!generaterandomtests::validRequestManyThreads(fn_list)) {
         std::cout << "validRequestManyThreads test failed." << std::endl;
+        failed++;
+    } else {
+        passed++;
+    }
+
+    if(!generaterandomtests::noReuseManyThreads(fn_list)) {
+        std::cout << "noReuseManyThreads test failed." << std::endl;
         failed++;
     } else {
         passed++;

--- a/integration-tests/test-sources/GenerateRandomTests.cpp
+++ b/integration-tests/test-sources/GenerateRandomTests.cpp
@@ -327,7 +327,7 @@ bool noReuseManyThreads(CK_FUNCTION_LIST_PTR fn_list) {
     std::thread threads[NUM_THREADS];
     CK_RV rvs[NUM_THREADS];
 
-    const size_t BYTES_PER_32_BITS = 4;
+    const size_t BYTES_PER_64_BITS = 8;
 
     rv = initializeMultiThreaded(fn_list);
     if(rv != CKR_OK) return false;
@@ -341,8 +341,8 @@ bool noReuseManyThreads(CK_FUNCTION_LIST_PTR fn_list) {
     CK_BYTE data[NUM_THREADS][MAX_REQUEST_SIZE_IN_BYTES];
 
     for(size_t i = 0; i < NUM_THREADS; i++) {
-        size_t size_in_32_bits = (rand() % MAX_REQUEST_SIZE_IN_BYTES) / BYTES_PER_32_BITS;
-        request_sizes_in_bytes[i] = BYTES_PER_32_BITS * size_in_32_bits;
+        size_t size_in_64_bits = (rand() % MAX_REQUEST_SIZE_IN_BYTES) / BYTES_PER_64_BITS;
+        request_sizes_in_bytes[i] = BYTES_PER_64_BITS * size_in_64_bits;
 
         for(size_t j = 0; j < MAX_REQUEST_SIZE_IN_BYTES; j++) {
             data[i][j] = (CK_BYTE)0;
@@ -363,14 +363,14 @@ bool noReuseManyThreads(CK_FUNCTION_LIST_PTR fn_list) {
             return false;
     }
 
-    std::set<uint32_t> seen;
+    std::set<uint64_t> seen;
 
     for(size_t i = 0; i < NUM_THREADS; i++) {
-        uint32_t *data_in_32_bits = (uint32_t *)data[i];
+        uint64_t *data_in_64_bits = (uint64_t *)data[i];
 
-        for(size_t j =  0; j < request_sizes_in_bytes[i] / BYTES_PER_32_BITS; j++) {
-            if(seen.count(data_in_32_bits[j]) != 0) return false;
-            seen.insert(data_in_32_bits[j]);
+        for(size_t j =  0; j < request_sizes_in_bytes[i] / BYTES_PER_64_BITS; j++) {
+            if(seen.count(data_in_64_bits[j]) != 0) return false;
+            seen.insert(data_in_64_bits[j]);
         }
     }
 

--- a/src/gtests/GenerateRandomTests.cpp
+++ b/src/gtests/GenerateRandomTests.cpp
@@ -245,9 +245,8 @@ TEST (GenerateRandomTests, ValidRequestManyThreads) {
 }
 
 /**
- * This test will fail with small probability due to the birthday paradox.
- * There are 2^32 possible uint32_t's, and we assume that ~6400 randomly chosen
- * uint32_t's will all be distinct. This is probably true, because 6400 << 2^(32/2)
+ * There are 2^64 possible uint64_t's, and we assume that ~3200 randomly chosen
+ * uint64_t's will all be distinct. This is probably true, because 3200 << 2^(64/2).
  */
 TEST (GenerateRandomTests, NoReuseManyThreads) {
     srand(time(NULL));
@@ -257,7 +256,7 @@ TEST (GenerateRandomTests, NoReuseManyThreads) {
     std::thread threads[NUM_THREADS];
     CK_RV rvs[NUM_THREADS];
 
-    const size_t BYTES_PER_32_BITS = 4;
+    const size_t BYTES_PER_64_BITS = 8;
 
     EXPECT_EQ(CKR_OK, initializeMultiThreaded());
 
@@ -268,8 +267,8 @@ TEST (GenerateRandomTests, NoReuseManyThreads) {
     CK_BYTE data[NUM_THREADS][MAX_REQUEST_SIZE_IN_BYTES];
 
     for(size_t i = 0; i < NUM_THREADS; i++) {
-        size_t size_in_32_bits = (rand() % MAX_REQUEST_SIZE_IN_BYTES) / BYTES_PER_32_BITS;
-        request_sizes_in_bytes[i] = BYTES_PER_32_BITS * size_in_32_bits;
+        size_t size_in_64_bits = (rand() % MAX_REQUEST_SIZE_IN_BYTES) / BYTES_PER_64_BITS;
+        request_sizes_in_bytes[i] = BYTES_PER_64_BITS * size_in_64_bits;
 
         for(size_t j = 0; j < MAX_REQUEST_SIZE_IN_BYTES; j++) {
             data[i][j] = (CK_BYTE)0;
@@ -289,14 +288,14 @@ TEST (GenerateRandomTests, NoReuseManyThreads) {
 
     EXPECT_EQ(CKR_OK, finalize());
 
-    std::set<uint32_t> seen;
+    std::set<uint64_t> seen;
 
     for(size_t i = 0; i < NUM_THREADS; i++) {
-        uint32_t *data_in_32_bits = (uint32_t *)data[i];
+        uint64_t *data_in_64_bits = (uint64_t *)data[i];
 
-        for(size_t j = 0; j < request_sizes_in_bytes[i] / BYTES_PER_32_BITS; j++) {
-            EXPECT_EQ(seen.count(data_in_32_bits[j]), 0);
-            seen.insert(data_in_32_bits[j]);
+        for(size_t j = 0; j < request_sizes_in_bytes[i] / BYTES_PER_64_BITS; j++) {
+            EXPECT_EQ(seen.count(data_in_64_bits[j]), 0);
+            seen.insert(data_in_64_bits[j]);
         }
     }
 }


### PR DESCRIPTION
Adds a unit + integration test to check that random is not reused in a multi-threaded setting.