### PR TITLE
Add corresponding munlock

### DIFF
--- a/src/lib/RandomBuffer.cpp
+++ b/src/lib/RandomBuffer.cpp
@@ -1,5 +1,4 @@
 #include <cstring>         // memset
-#include <sys/mman.h>      // mlock
 #include <stdexcept>       // std::runtime_error
 
 #include "log.h"           // DEBUG_MSG

--- a/src/lib/RandomBuffer.h
+++ b/src/lib/RandomBuffer.h
@@ -6,6 +6,7 @@
 #define _QRYPT_WRAPPER_RANDOMBUFFER_H
 
 #include <memory>
+#include <sys/mman.h>          // m(un)lock
 
 #include "cryptoki.h"          // CK_RV
 
@@ -13,6 +14,7 @@
 
 struct BufferDeleter {
     void operator() (uint8_t *buffer_ptr) const {
+        munlock(buffer_ptr, KB * sizeof(uint8_t));
         free(buffer_ptr);
     }
 };


### PR DESCRIPTION
Fixes failure of qryptoki_gtests with the --gtest_repeat set to a large number.

Root cause: Each GenerateRandomTest and BufferTest was "mlock"ing another page for the buffer, and they were never "munlock"ed. Once the limit was reached, no more buffers could be created.