### PR TITLE
Assert no throws in RandomBuffer constructor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 
-set(CMAKE_CXX_STANDARD          14) 
+set(CMAKE_CXX_STANDARD          17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS        OFF)
 
 project(Qrypt-PKCS-11 LANGUAGES CXX)
 


### PR DESCRIPTION
I didn't love the fact that constructing RandomBuffers in BufferTests.cpp could throw an uncaught exception, but let me know if you think this is unnecessary.

Also updates everything to C++17 (required in order to use std::optional)